### PR TITLE
Fixes for EKS

### DIFF
--- a/kubernetes/redpanda/templates/configmap.yaml
+++ b/kubernetes/redpanda/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
         {{- range untilStep 0 (.Values.replicaCount|int) 1 }}
         - node_id: {{ . }}
           host:
-            address: {{ template "redpanda.name" $envAll }}-{{ . }}.{{ template "redpanda.name" $envAll }}
+            address: {{ template "redpanda.name" $envAll }}-{{ . }}.{{ template "redpanda.name" $envAll }}.{{ $envAll.Release.Namespace }}.svc.{{ $envAll.Values.clusterDomain }}
             port: {{ $envAll.Values.config.redpanda.advertised_rpc_api.port }}
         {{- end }}
     rpk:

--- a/kubernetes/redpanda/templates/headless-service.yaml
+++ b/kubernetes/redpanda/templates/headless-service.yaml
@@ -6,6 +6,7 @@ metadata:
    {{- include "redpanda.labels" . | nindent 4 }} 
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: kafka-tcp
       protocol: TCP

--- a/kubernetes/redpanda/templates/statefulset.yaml
+++ b/kubernetes/redpanda/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
             - >
               CONFIG=/tmp/config/redpanda.yaml;
               NODE_ID=${HOSTNAME##*-};
-              SERVICE_NAME={{ template "redpanda.name" . }}-$NODE_ID.{{ template "redpanda.name" . }};
+              SERVICE_NAME={{ template "redpanda.name" . }}-$NODE_ID.{{ template "redpanda.name" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }};
               cp /tmp/base-config/redpanda.yaml $CONFIG;
               rpk --config $CONFIG config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then
@@ -43,14 +43,16 @@ spec:
             requests:
               cpu: 1
               memory: 128Mi
+      subdomain: {{ template "redpanda.name" . }}
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository }}
           args:
-           - --config /tmp/config/redpanda.yaml
-           - start
-           - --
-           - --default-log-level={{ .Values.config.seastar.default_log_level }}
+           - >
+              --config /tmp/config/redpanda.yaml
+              start
+              --
+              --default-log-level={{ .Values.config.seastar.default_log_level }}
           ports:
             - containerPort: {{ .Values.config.redpanda.admin.port }}
               name: admin

--- a/kubernetes/redpanda/values.yaml
+++ b/kubernetes/redpanda/values.yaml
@@ -10,6 +10,8 @@
 
 replicaCount: 3
 
+clusterDomain: cluster.local
+
 image:
   repository: vectorized/redpanda
   # The imagePullPolicy will default to Always when the tag is 'latest'


### PR DESCRIPTION
Fixed up the DNS names to match what was seen. Which was similar to
redpanda-0.redpanda.redpanda.svc.cluster.local. This could probably be
cleaned up.

Also added the rpc port to the headless service and said to publish not
ready addresses.